### PR TITLE
Update to error-first callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,9 @@
 			var script = document.createElement('script');
 			script.type = 'text/javascript';
 			script.src = this.src;
+			script.addEventListener('error', function() {
+				TwitterWidgetsLoader.done(new Error('Twitter widgets JS failed to load. Is there an ad blocker enabled?'));
+			});
 			document.body.appendChild(script);
 
 			this.poll();
@@ -43,9 +46,9 @@
 			}, this.interval);
 		},
 
-		done: function() {
+		done: function(error) {
 			while(this.listeners.length) {
-				this.listeners.pop()(window.twttr);
+				this.listeners.pop()(error, window.twttr);
 			}
 		}
 	};


### PR DESCRIPTION
Added an error state so we can detect when the Twitter script fails to load (commonly because of adblock). This allows us to perform some other action, such as showing alternative content.

This is a breaking change, so if it's accepted should probably bump the version to 2.0.0.